### PR TITLE
Don't strip trailing slashes on request paths

### DIFF
--- a/env.go
+++ b/env.go
@@ -69,8 +69,7 @@ func (p *PruxyEnv) DefaultRequestConverter() func(*http.Request, *http.Request) 
 }
 
 func (p *PruxyEnv) convert(originalRequest, proxy *http.Request) {
-	originalPath := removeTrailingSlash(originalRequest.URL.Path)
-	originalHostPath := &HostPath{originalRequest.Host, originalPath}
+	originalHostPath := &HostPath{originalRequest.Host, originalRequest.URL.Path}
 
 	p.mu.Lock()
 	defer p.mu.Unlock()


### PR DESCRIPTION
Sometimes these are significant (in Flask apps, for example), and stripping them can cause 404s or redirect loops.
